### PR TITLE
improvement: add target blank for link

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
   <link rel="stylesheet" href="css/explosion.css">
   <link rel="stylesheet" href="./css/terminal.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@3.5.2/animate.min.css">
-  <title>Hacktoberfest 2018 - Contributors</title>
+  <title>Hacktoberfest 2020 - Contributors</title>
 </head>
 
 <body>
@@ -92,25 +92,26 @@
       <p class="animated rubberBand delay-4s">Add yourself to the list if you contribute.</p>
       <div class="box mx-auto">
 	      <!-- Add to the bottom of the list -->
-        <a class="box-item" href="https://github.com/fineanmol"><span>Anmol Agarwal</span></a>
-        <a class="box-item" href="https://github.com/Amitava123"><span>Amitava Mitra</span></a>
-        <a class="box-item" href="https://github.com/philson-philip"><span>Philson Philip</span></a>
-        <a class="box-item" href="https://github.com/SHIV1003"><span>Shivam Goyal</span></a>
-        <a class="box-item" href="https://github.com/shradha-khapra"><span>Shradha Khapra</span></a>
-        <a class="box-item" href="https://github.com/ritesh2905"><span>Ritesh Kumar</span></a>
-        <a class="box-item" href="https://github.com/xevenheaven"><span>Elysia Ong</span></a>
-	    	<a class="box-item" href="https://github.com/facundof13"><span>Facundo</span></a>
-	    	<a class="box-item" href="https://github.com/Aashik96"><span>Aashik Ahamed</span></a>
-		    <a class="box-item" href="https://github.com/zonex909"><span>Rupna Maitra</span></a>
-		    <a class="box-item" href="https://github.com/sharron4me"><span>Mohammad Ummair</span></a>
-	    	<a class="box-item" href="https://github.com/Rajat-sharMaa"><span>Rajat Shamraa</span></a>
-	    	<a class="box-item" href="https://github.com/20manas"><span>Manas Khurana</span></a>
-	    	<a class="box-item" href="https://github.com/rishurajcambrdg"><span>Rishu Raj</span></a>
-      	<a class="box-item" href="https://github.com/manigedit"><span>Manish Kumar</span></a>
-	    	<a class="box-item" href="https://github.com/nnishad"><span>Nikhil Nishad</span></a>
-        <a class="box-item" href="https://github.com/aortizoj15"><span>Alexis Ortiz Ojeda</span></a>
-	      <a class="box-item" href="https://github.com/Starfire1853"><span>Lynn Nguyen</span></a> 
-        <a class="box-item" href="https://github.com/Triben-Choudhary"><span>Triben Choudhary</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/fineanmol"><span>Anmol Agarwal</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/Amitava123"><span>Amitava Mitra</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/philson-philip"><span>Philson Philip</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/SHIV1003"><span>Shivam Goyal</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/shradha-khapra"><span>Shradha Khapra</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/ritesh2905"><span>Ritesh Kumar</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/xevenheaven"><span>Elysia Ong</span></a>
+	    	<a class="box-item" target="_blank" href="https://github.com/facundof13"><span>Facundo</span></a>
+	    	<a class="box-item" target="_blank" href="https://github.com/Aashik96"><span>Aashik Ahamed</span></a>
+		    <a class="box-item" target="_blank" href="https://github.com/zonex909"><span>Rupna Maitra</span></a>
+		    <a class="box-item" target="_blank" href="https://github.com/sharron4me"><span>Mohammad Ummair</span></a>
+	    	<a class="box-item" target="_blank" href="https://github.com/Rajat-sharMaa"><span>Rajat Shamraa</span></a>
+	    	<a class="box-item" target="_blank" href="https://github.com/20manas"><span>Manas Khurana</span></a>
+	    	<a class="box-item" target="_blank" href="https://github.com/rishurajcambrdg"><span>Rishu Raj</span></a>
+      	<a class="box-item" target="_blank" href="https://github.com/manigedit"><span>Manish Kumar</span></a>
+	    	<a class="box-item" target="_blank" href="https://github.com/nnishad"><span>Nikhil Nishad</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/aortizoj15"><span>Alexis Ortiz Ojeda</span></a>
+	      <a class="box-item" target="_blank" href="https://github.com/Starfire1853"><span>Lynn Nguyen</span></a> 
+        <a class="box-item" target="_blank" href="https://github.com/Triben-Choudhary"><span>Triben Choudhary</span></a>
+        <a class="box-item" target="_blank" href="https://github.com/helangeline"><span>Angeline Budinata</span></a>
 
         <!--
         Add here

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -34,7 +34,7 @@ function buildMenuHTML (obj = {}) {
         let isCurrent = (currentPage === item.href)
 
         html += '<div class="nav-item' + (isCurrent ? ' active' : '') + '">'
-        html += '<a class="nav-link" href="' + item.href + '"' + (item.id ? ' id="' + item.id + '"' : '') + '>' + item.text + '</a>'
+        html += '<a target="_blank" class="nav-link" href="' + item.href + '"' + (item.id ? ' id="' + item.id + '"' : '') + '>' + item.text + '</a>'
         html += '</div>'
       })
       html += '</div>'
@@ -46,7 +46,7 @@ function buildMenuHTML (obj = {}) {
       let isCurrent = (currentPage === item.href)
 
       html += '<li class="nav-item' + (isCurrent ? ' active' : '') + '">'
-      html += '<a class="nav-link" href="' + item.href + '"' + (item.id ? ' id="' + item.id + '"' : '') + '>' + item.text + '</a>'
+      html += '<a target="_blank" class="nav-link" href="' + item.href + '"' + (item.id ? ' id="' + item.id + '"' : '') + '>' + item.text + '</a>'
       html += '</li>'
     }
   })


### PR DESCRIPTION
# Problem
- When click one of the link in home, user will leave your site

# Solution
- Add target blank, so user still on your page, and can see other link

## Changes proposed in this Pull Request :
-  Add target blank for github contributors
-  Add target blank for menu

## Other changes
- Change the year of title in index, its still 2018 instead of 2020