### PR TITLE
Fixed profiles broken links

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -119,7 +119,7 @@
 <a class="box-item" href="https://github.com/Rajat-sharMaa"><span>Rajat Shamraa</span></a>	      	
 <a class="box-item" href="https://github.com/20manas"><span>Manas Khurana</span></a>
 <a class="box-item" href="https://github.com/manigedit"><span>Manish Kumar</span></a>
-<a class="box-item" href="https://github.com/rishurajcambrdg"><span>Rishu Raj</span></a>
+<a class="box-item" href="https://github.com/vakilsahabh"><span>Vakeel Sahabh</span></a>
 <a class="box-item" href="https://github.com/randymfournier"><span>Randy M Fournier</span></a> 
 <a class="box-item" href="https://github.com/ruchirtoshniwal"><span>Ruchir Toshniwal</span></a>             
 <a class="box-item" href="https://github.com/juniorhero"><span>Athul Jayaram</span></a> 
@@ -137,9 +137,9 @@
 <a class="box-item" href="https://github.com/senshiii"><span>Sayan Das</span></a>
 <a class="box-item" href="https://github.com/Shagufta08"><span>Shagufta Iqbal</span></a>
 <a class="box-item" href="https://github.com/ishgary"><span>Ishant Garg</span></a>
-<a class="box-item" href="https://github.com/<Sauvic016>"><span>Sauvic P Choudhury </span></a>
-<a class="box-item" href="https://github.com/<panchadeep>"><span>Panchadeep Mazumder</span></a>
-<a class="box-item" href="https://github.com/savarbhasin>"><span>Savar Bhasin</span></a>
+<a class="box-item" href="https://github.com/Sauvic016"><span>Sauvic P Choudhury </span></a>
+<a class="box-item" href="https://github.com/panchadeep"><span>Panchadeep Mazumder</span></a>
+<a class="box-item" href="https://github.com/savarbhasin"><span>Savar Bhasin</span></a>
 <a class="box-item" href="https://github.com/nitin-jain3"><span>NITIN JAIN</span></a>
 <a class="box-item" href="https://github.com/MasterBrian99"><span>Pasindu P Konghawaththa</span></a>
 <a class="box-item" href="https://github.com/pepeyen"><span>Erick Frederick</span></a>


### PR DESCRIPTION

# Problem
- A few profiles link was broken due to typos or updates.
# Solution
- Fixed typos and updated properly
## Changes proposed in this Pull Request :
-  `1.` Updated link User name and Display Name `122` based on the #19 commit (a1b63af) author 
-  `2.` Removed `<` & `>` from line `140` based on the #51 commit (f4e2a41) author
-  `3.` Removed `<` & `>` from line`141` based on the #52  commit (1e63a20) author
-  `4.` Removed `>` from line `142` based on the #54 commit (ec2f7b5) author